### PR TITLE
Add style check job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,18 @@ jobs:
         run: |
           go test -cover ./...
           exit 0
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.0"
+
+      - name: Check formatting
+        run: test -z $(go fmt ./...)


### PR DESCRIPTION
Introduce a new job in the CI workflow to check Go code formatting using `go fmt`. This ensures code style consistency across the project.